### PR TITLE
Arrumando a busca binária

### DIFF
--- a/src/go/busca_binaria/busca_binaria.go
+++ b/src/go/busca_binaria/busca_binaria.go
@@ -9,10 +9,10 @@ func binarySearch(seq []int, element, start, end int) int {
 
 	if start != end {
 		if seq[index] < element {
-			return binarySearch(seq, element, start+1, end)
+			return binarySearch(seq, element, index+1, end)
 		}
 
-		return binarySearch(seq, element, start, end-1)
+		return binarySearch(seq, element, start, index-1)
 	}
 
 	return -1


### PR DESCRIPTION
Percebi que a busca binária não estava tão efetiva quanto deveria:

![image](https://user-images.githubusercontent.com/36492293/128608198-358e046c-934a-4e1d-b061-f3ff0eac6f4d.png)

Então "arrumei" ela, fazendo com que o número de elementos sempre fosse cortado pela metade a cada recursão:

![image](https://user-images.githubusercontent.com/36492293/128608209-1a24addf-6ee6-499c-93ec-3a5f1be260d2.png)
